### PR TITLE
Add example of EKS managed cluster

### DIFF
--- a/infrastructure/terraform/kubernetes-managed/.terraform.lock.hcl
+++ b/infrastructure/terraform/kubernetes-managed/.terraform.lock.hcl
@@ -1,0 +1,85 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.36.0"
+  constraints = ">= 4.33.0, >= 5.20.0, >= 5.34.0, ~> 5.36"
+  hashes = [
+    "h1:cW6lxWiyfTlJAS0TK5VXZzddB6xKhRxc3PZo73jWuP0=",
+    "zh:0da8409db879b2c400a7d9ed1311ba6d9eb1374ea08779eaf0c5ad0af00ac558",
+    "zh:1b7521567e1602bfff029f88ccd2a182cdf97861c9671478660866472c3333fa",
+    "zh:1cab4e6f3a1d008d01df44a52132a90141389e77dbb4ec4f6ac1119333242ecf",
+    "zh:1df9f73595594ce8293fb21287bcacf5583ae82b9f3a8e5d704109b8cf691646",
+    "zh:2b5909268db44b6be95ff6f9dc80d5f87ca8f63ba530fe66723c5fdeb17695fc",
+    "zh:37dd731eeb0bc1b20e3ec3a0cb5eb7a730edab425058ff40f2243438acc82830",
+    "zh:3e94c76a2b607a1174d10f5712aed16cb32216ac1c91bd6f21749d61a14045ac",
+    "zh:40e6ba3184d2d3bf283a07feed8b79c1bbc537a91215cac7b3521b9ccb3e503e",
+    "zh:67e52353fea47eb97825f6eb6fddd1935e0ff3b53a8861d23a70c2babf83ae51",
+    "zh:6d2e2f390e0c7b2cd2344b1d5d6eec8a1c11cf35d19f1d6f341286f2449e9e10",
+    "zh:7005483c43926800fad5bb18e27be883dac4339edb83a8f18ccdc7edf86fafc2",
+    "zh:7073fa7ccaa9b07c2cf7b24550a90e11f4880afd5c53afd51278eff0154692a0",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a6d48620e526c766faec9aeb20c40a98c1810c69b6699168d725f721dfe44846",
+    "zh:e29b651b5f39324656f466cd24a54861795cc423a1b58372f4e1d2d2112d10a0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.3"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
+    "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
+    "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
+    "zh:32764cfcff0d7379ca8b7dde376ac5551854d454c5881945f1952b785a312fa2",
+    "zh:55c2a4dc3ebdeaa1dec3a36db96dab253c7fa10b9fe1209862e1ee77a01e0aa1",
+    "zh:5c71f260ba5674d656d12f67cde3bb494498e6b6b6e66945ef85688f185dcf63",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9617280a853ec7caedb8beb7864e4b29faf9c850a453283980c28fccef2c493d",
+    "zh:ac8bda21950f8dddade3e9bc15f7bcfdee743738483be5724169943cafa611f5",
+    "zh:ba9ab567bbe63dee9197a763b3104ea9217ba27449ed54d3afa6657f412e3496",
+    "zh:effd1a7e34bae3879c02f03ed3afa979433a518e11de1f8afd35a8710231ac14",
+    "zh:f021538c86d0ac250d75e59efde6d869bbfff711eb744c8bddce79d2475bf46d",
+    "zh:f1e3984597948a2103391a26600e177b19f16a5a4c66acee27a4343fb141571f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.10.0"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
+    "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
+    "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",
+    "zh:3bbb3e9da728b82428c6f18533b5b7c014e8ff1b8d9b2587107c966b985e5bcc",
+    "zh:6771c72db4e4486f2c2603c81dfddd9e28b6554d1ded2996b4cb37f887b467de",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:833c636d86c2c8f23296a7da5d492bdfd7260e22899fc8af8cc3937eb41a7391",
+    "zh:c545f1497ae0978ffc979645e594b57ff06c30b4144486f4f362d686366e2e42",
+    "zh:def83c6a85db611b8f1d996d32869f59397c23b8b78e39a978c8a2296b0588b2",
+    "zh:df9579b72cc8e5fac6efee20c7d0a8b72d3d859b50828b1c473d620ab939e2c7",
+    "zh:e281a8ecbb33c185e2d0976dc526c93b7359e3ffdc8130df7422863f4952c00e",
+    "zh:ecb1af3ae67ac7933b5630606672c94ec1f54b119bf77d3091f16d55ab634461",
+    "zh:f8109f13e07a741e1e8a52134f84583f97a819e33600be44623a21f6424d6593",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.5"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
+    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
+    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
+    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
+    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
+    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
+    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
+    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
+    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
+    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
+    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
+    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/terraform/kubernetes-managed/aws.tf
+++ b/infrastructure/terraform/kubernetes-managed/aws.tf
@@ -1,0 +1,16 @@
+################################################################################
+## This file contains the AWS provider.
+## https://registry.terraform.io/providers/hashicorp/aws/latest/docs
+################################################################################
+
+# The instance of the AWS provider.
+provider "aws" {
+  # The default region used to provision resources.
+  region = "eu-west-1"
+
+  # The access credentials passed as variables by Terraform Cloud.
+  access_key = var.AWS_ACCESS_KEY_ID
+  secret_key = var.AWS_SECRET_ACCESS_KEY
+}
+
+data "aws_caller_identity" "current" {}

--- a/infrastructure/terraform/kubernetes-managed/backend.tf
+++ b/infrastructure/terraform/kubernetes-managed/backend.tf
@@ -1,0 +1,24 @@
+################################################################################
+## This file contains the configuration of Terraform Cloud and its providers.
+################################################################################
+
+terraform {
+  cloud {
+    organization = "noi-digital"
+
+    workspaces {
+      tags = ["opendatahub-kubernetes-managed"]
+    } 
+  }
+
+  required_providers {
+    # The configuration of the AWS provider and its required version.
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.36"
+    }
+  }
+
+  # The required version of Terraform itself.
+  required_version = "~> 1.7"
+}

--- a/infrastructure/terraform/kubernetes-managed/eks.tf
+++ b/infrastructure/terraform/kubernetes-managed/eks.tf
@@ -1,0 +1,99 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.2.1"
+
+  # ----------------------------------------------------------------------------
+  # General
+  # ----------------------------------------------------------------------------
+  cluster_name    = "aws-main-eu-02"
+  cluster_version = "1.29"
+
+  # ----------------------------------------------------------------------------
+  # Control Plane Access
+  # ----------------------------------------------------------------------------
+  cluster_endpoint_public_access = true
+
+  # ----------------------------------------------------------------------------
+  # Network
+  # ----------------------------------------------------------------------------
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  # ----------------------------------------------------------------------------
+  # Cluster Permissions - add the current caller identity as an administrator.
+  # ----------------------------------------------------------------------------
+  enable_cluster_creator_admin_permissions = true
+
+  # ----------------------------------------------------------------------------
+  # Addons
+  # ----------------------------------------------------------------------------
+  cluster_addons = {
+    coredns = {
+      most_recent = true
+    }
+    kube-proxy = {
+      most_recent = true
+    }
+    vpc-cni = {
+      most_recent    = true
+      before_compute = true
+      configuration_values = jsonencode({
+        env = {
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+        }
+      })
+    }
+  }
+
+  # ----------------------------------------------------------------------------
+  # Node Groups
+  # ----------------------------------------------------------------------------
+  eks_managed_node_groups = {
+    main = {
+      name = "main-pool"
+
+      # Node group autoscaling.
+      max_size     = 5
+      desired_size = 3
+      min_size     = 3 # NOTE: the minimum size must be at least equal to the amount of subnets (zones).
+
+      # Node instances.
+      instance_type = "t3.medium"
+
+      use_custom_launch_template = false
+
+      ami_type = "BOTTLEROCKET_x86_64"
+      platform = "bottlerocket"
+    }
+  }
+
+  # ----------------------------------------------------------------------------
+  # Authentication & Authorization
+  #
+  # https://aws.amazon.com/blogs/containers/a-deep-dive-into-simplified-amazon-eks-access-management-controls/
+  # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+  # ----------------------------------------------------------------------------
+  access_entries = {
+    # Animeshon.
+    animeshon = {
+      kubernetes_groups = []
+      principal_arn     = "arn:aws:iam::828408288281:user/animeshon"
+
+      policy_associations = {
+        default = {
+          # Values: [AmazonEKSClusterAdminPolicy, AmazonEKSAdminPolicy, AmazonEKSEditPolicy, AmazonEKSViewPolicy].
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            # Values: [cluster, namespace].
+            type       = "cluster",
+            namespaces = []
+          }
+        }
+      }
+    }
+
+    # NOTE: the Terraform Access Entry has already been created by the module.
+    # See `enable_cluster_creator_admin_permissions` option for more information.
+  }
+}

--- a/infrastructure/terraform/kubernetes-managed/variables.tf
+++ b/infrastructure/terraform/kubernetes-managed/variables.tf
@@ -1,0 +1,15 @@
+################################################################################
+## This file contains the veriables provided by Terraform Cloud.
+## https://www.terraform.io/language/values/variables
+################################################################################
+
+# The environment variables used to access AWS through a service account.
+variable "AWS_ACCESS_KEY_ID" {
+  type    = string
+  default = ""
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
+  type    = string
+  default = ""
+}

--- a/infrastructure/terraform/kubernetes-managed/vpc.tf
+++ b/infrastructure/terraform/kubernetes-managed/vpc.tf
@@ -1,0 +1,24 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.5"
+
+  name = "internal-vpc-02"
+  cidr = "10.1.0.0/16"
+
+  azs = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+
+  private_subnets = ["10.1.1.0/24", "10.1.2.0/24", "10.1.3.0/24"]
+  public_subnets  = ["10.1.4.0/24", "10.1.5.0/24", "10.1.6.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+}


### PR DESCRIPTION
This ticket introduces a new cluster that has been deployed in the development environment, relying on the EKS-managed cluster and node pools. The configuration appears to be more streamlined and better supported compared to the currently employed self-managed version.

If you decide to move forward with managed EKS, please be aware that additional addons, such as the cluster autoscaler and CSI, need to be implemented. The implementation should be straightforward, as it closely mirrors the existing setup for the self-managed node groups and control planes.

Feel free to destroy the cluster and all associated resources once they are no longer needed. I've duplicated all resources, including the VPC, to ensure it won't interfere with the already operational self-managed cluster.

P.S. It is advisable to agree on whether to proceed with the self-managed or the managed cluster before launching the first service into production.

If you want to authenticate to the cluster you can use the following command, do not forget to add your own `access_entries` with your user ARN and `AmazonEKSClusterAdminPolicy` policy:

```
aws eks --region eu-west-1 update-kubeconfig --name aws-main-eu-02
```

This ticket closes https://github.com/noi-techpark/odh-infrastructure-v2/issues/14.